### PR TITLE
destroy this.embla instance when unmounting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,10 @@ class EmblaCarouselReact extends Component<PropType> {
     )
     if (this.props.emblaRef) this.props.emblaRef(this.embla)
   }
+  
+  componentWillUnmount() {
+    if (this.embla) this.embla.destroy()
+  }
 
   render() {
     return React.createElement(


### PR DESCRIPTION
The current embla instance is not destroyed when the component gets unmounted. This can result in possible memory leaks when you create multiple emblas on your SPA. Am I missing something? I propose this file change to the react wrapper:

```js
componentWillUnmount() {
    if (this.embla) this.embla.destroy()
}
```